### PR TITLE
Fix product search for out-of-stock items

### DIFF
--- a/ajax-handler.php
+++ b/ajax-handler.php
@@ -29,7 +29,8 @@ if ($accion === 'buscar') {
     if ($query->have_posts()) {
         foreach ($query->posts as $post) {
             $product = wc_get_product($post->ID);
-            if (!$product || !$product->is_in_stock()) continue;
+            // se permite mostrar productos sin stock para evitar que queden fuera de las búsquedas
+            if (!$product) continue;
 
             $moq = get_post_meta($post->ID, 'min_quantity', true);
             $moq = intval($moq) ?: 1;

--- a/nueva.php
+++ b/nueva.php
@@ -246,7 +246,7 @@ const imagenes = [
 
     // Búsqueda AJAX de productos
     input.addEventListener('input', function () {
-        const term = this.value;
+        const term = this.value.trim();
         if (term.length < 3) {
             resultados.innerHTML = '';
             return;


### PR DESCRIPTION
## Summary
- return products regardless of stock status in search AJAX handler
- trim search text on the client before querying

## Testing
- `php -l ajax-handler.php`
- `php -l nueva.php`


------
https://chatgpt.com/codex/tasks/task_e_688113ac7fa88332a4a45727460eb01b