### PR TITLE
Fix missing prices in product search

### DIFF
--- a/ajax-handler.php
+++ b/ajax-handler.php
@@ -32,6 +32,21 @@ if ($accion === 'buscar') {
             // se permite mostrar productos sin stock para evitar que queden fuera de las búsquedas
             if (!$product) continue;
 
+            $price = $product->get_price();
+            if ($price === '' || $price === null || !is_numeric($price)) {
+                $price = '';
+                if ($product->is_type('variable')) {
+                    foreach ($product->get_children() as $child_id) {
+                        $child = wc_get_product($child_id);
+                        $child_price = $child ? $child->get_price() : '';
+                        if ($child_price !== '' && $child_price !== null && is_numeric($child_price)) {
+                            $price = $child_price;
+                            break;
+                        }
+                    }
+                }
+            }
+
             $moq = get_post_meta($post->ID, 'min_quantity', true);
             $moq = intval($moq) ?: 1;
 
@@ -52,7 +67,7 @@ $results[] = [
     'id'          => $product->get_id(),
     'name'        => $product->get_name(),
     'sku'         => $product->get_sku(),
-    'price'       => $product->get_price(),
+    'price'       => ($price !== '' ? floatval($price) : 0),
     'moq'         => $moq,
     'image'       => $imagenes[0] ?? '',
     'imagenes'    => $imagenes,

--- a/nueva.php
+++ b/nueva.php
@@ -262,17 +262,18 @@ const imagenes = [
                     li.style.display = 'flex';
                     li.style.alignItems = 'center';
                     li.style.borderBottom = '1px solid #eee';
+                    const precioNum = parseFloat(producto.price);
                     li.innerHTML = `
                         <img src="${producto.image}" width="40" height="40" style="border-radius:6px; margin-right:10px;">
                         <div>
                             <strong>${producto.name}</strong><br>
-                            <small>SKU: ${producto.sku} | $${parseFloat(producto.price).toLocaleString()}</small>
+                            <small>SKU: ${producto.sku} | $${isNaN(precioNum) ? '0' : precioNum.toLocaleString()}</small>
                         </div>`;
                     li.addEventListener('click', () => {
                         agregarProducto({
                             name: producto.name,
                             sku: producto.sku,
-                            price: producto.price,
+                            price: isNaN(precioNum) ? 0 : precioNum,
                             moq: producto.moq,
                             imagenes: producto.imagenes,
                             image: producto.image,


### PR DESCRIPTION
## Summary
- check variable children for a price when the parent product price is missing
- parse product price in search results before displaying

## Testing
- `php -l ajax-handler.php`
- `php -l nueva.php`
- `for f in login.php pdf.php dashboard.php logout.php ajax-handler.php router.php nueva.php; do php -l $f || break; done`

------
https://chatgpt.com/codex/tasks/task_e_6881177a0d7c83329cf6942c93a096ec