### PR TITLE
Fix sorting to prioritize priced products

### DIFF
--- a/ajax-handler.php
+++ b/ajax-handler.php
@@ -33,16 +33,17 @@ if ($accion === 'buscar') {
             if (!$product) continue;
 
             $price = $product->get_price();
-            if ($price === '' || $price === null || !is_numeric($price)) {
-                $price = '';
-                if ($product->is_type('variable')) {
-                    foreach ($product->get_children() as $child_id) {
-                        $child = wc_get_product($child_id);
-                        $child_price = $child ? $child->get_price() : '';
-                        if ($child_price !== '' && $child_price !== null && is_numeric($child_price)) {
-                            $price = $child_price;
-                            break;
-                        }
+
+            // Si el precio está vacío o es menor o igual a cero, y es un producto
+            // variable, intentamos obtener el precio de alguna variación
+            if (($price === '' || $price === null || !is_numeric($price) || floatval($price) <= 0)
+                && $product->is_type('variable')) {
+                foreach ($product->get_children() as $child_id) {
+                    $child = wc_get_product($child_id);
+                    $child_price = $child ? $child->get_price() : '';
+                    if ($child_price !== '' && $child_price !== null && is_numeric($child_price) && floatval($child_price) > 0) {
+                        $price = $child_price;
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- improve price lookup for variable products so priced variations are considered

## Testing
- `php -l ajax-handler.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_68811a381d0883329c82ae720cccf631