### PR TITLE
Filtra productos sin precio

### DIFF
--- a/ajax-handler.php
+++ b/ajax-handler.php
@@ -48,6 +48,11 @@ if ($accion === 'buscar') {
                 }
             }
 
+            $price_val = ($price !== '' ? floatval($price) : 0);
+            if ($price_val <= 0) {
+                continue; // omitir productos sin precio válido
+            }
+
             $moq = get_post_meta($post->ID, 'min_quantity', true);
             $moq = intval($moq) ?: 1;
 
@@ -68,7 +73,7 @@ $results[] = [
     'id'          => $product->get_id(),
     'name'        => $product->get_name(),
     'sku'         => $product->get_sku(),
-    'price'       => ($price !== '' ? floatval($price) : 0),
+    'price'       => $price_val,
     'moq'         => $moq,
     'image'       => $imagenes[0] ?? '',
     'imagenes'    => $imagenes,


### PR DESCRIPTION
## Summary
- evita incluir en los resultados del buscador productos con precio vacío o 0

## Testing
- `php -l ajax-handler.php`
- `php -l nueva.php`


------
https://chatgpt.com/codex/tasks/task_e_68811b41fba883328a4b3c123835b9aa