### PR TITLE
Fix search results missing due to price filters

### DIFF
--- a/ajax-handler.php
+++ b/ajax-handler.php
@@ -20,7 +20,8 @@ if ($accion === 'buscar') {
         'post_type'      => 'product',
         'post_status'    => 'publish',
         's'              => $term,
-        'posts_per_page' => 6,
+        // buscamos más productos en caso de que varios sean filtrados luego
+        'posts_per_page' => 20,
     ];
 
     $query = new WP_Query($args);
@@ -100,7 +101,8 @@ $results[] = [
         return 0;
     });
 
-    wp_send_json($ordenados);
+    // limitamos la respuesta a 6 productos
+    wp_send_json(array_slice($ordenados, 0, 6));
 }
 
 


### PR DESCRIPTION
## Summary
- fetch more products in search so filtered ones don't remove everything
- cap search results to six items after sorting

## Testing
- `php -l ajax-handler.php`
- `php -l nueva.php`
- `php -l dashboard.php`
- `php -l login.php`
- `php -l logout.php`
- `php -l pdf.php`
- `php -l router.php`
- `php -l admin/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68811c8bd6748332ab62df563b177d0b